### PR TITLE
updated ort submodule to latest commit

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -24,4 +24,4 @@ jobs:
         dockerfile: Dockerfile
         base-dir: latest/ort
         image-name: ort
-        tags: latest 2021-05-31
+        tags: latest 2021-10-06


### PR DESCRIPTION
Apparently, there is an issue with ca-certificates that occurs, when trying to run `apt-get update` within the philipssoftware/ort container, see e.g. https://github.com/nodesource/distributions/issues/1266.

In the ORT repository, this has been fixed recently: https://github.com/oss-review-toolkit/ort/commit/3f4c933288848799a247c0c5e4e705c66bb66d95

Therefore, I propose to pin a newer version of ORT in order to get a working ORT base image.